### PR TITLE
Fix require in lib to grab the right file

### DIFF
--- a/lib/capistrano-campfire.rb
+++ b/lib/capistrano-campfire.rb
@@ -1,1 +1,1 @@
-require 'capistrano/tinder'
+require 'capistrano/campfire'


### PR DESCRIPTION
Currently the lib is trying to require `capistrano/tinder` instead of `capistrano/campfire`. This causes issues when loading the gem.
